### PR TITLE
Add script for building the .deb in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+*.deb

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Created by https://www.gitignore.io/api/maven,intellij
 # Edit at https://www.gitignore.io/?templates=maven,intellij
 
+*.deb
+
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:21-jdk-slim-bullseye
+
+RUN apt-get -qy update
+RUN apt-get -qy install maven
+RUN apt-get -qy install lsb-release
+
+WORKDIR /root
+RUN mkdir /root/OUTPUT
+COPY . .

--- a/build-deb-in-docker.sh
+++ b/build-deb-in-docker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+IMG="keycloak-debian:latest"
+
+docker build -t $IMG .
+docker run --rm -iv${PWD}:/root/OUTPUT $IMG sh -s << EOF
+    cd /root
+    mvn clean package || exit 1
+    chown -v $(id -u):$(id -g) target/*.deb
+    cp -va target/*.deb OUTPUT/
+    echo "============ Done. Built for: ============="
+    lsb_release -a
+EOF
+echo "=============== $(pwd) ==============="
+ls -l *.deb


### PR DESCRIPTION
This PR adds script `./build-deb-in-docker.sh` that spins up a Docker image,
installs Maven in it, builds the .deb and leaves.

This approach allows making the deb anywhere without installing JDK, Maven etc. locally.